### PR TITLE
Add copy over from github scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
 # Install svn to copy folder from github
 RUN apt-get update && apt-get install -y --no-install-recommends subversion
 
-ADD scripts/ ./ottr_report_scripts/
-ADD main.sh ./ottr_report_scripts/main.sh
+COPY scripts/ ./ottr_report_scripts/
+COPY main.sh ./ottr_report_scripts/main.sh
 RUN chmod +x ./ottr_report_scripts/main.sh
 
 WORKDIR /github/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'optparse'), \
       repos = 'https://cloud.r-project.org/')"
 
-# Install svn to copy folder from github
-RUN apt-get update && apt-get install -y --no-install-recommends subversion
-
 COPY main.sh ./main.sh
 RUN chmod +x ./main.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'optparse'), \
       repos = 'https://cloud.r-project.org/')"
 
-COPY main.sh ./main.sh
-RUN chmod +x ./main.sh
+COPY main.sh ./ottr_report_scripts/main.sh
+RUN chmod +x ./ottr_report_scripts/main.sh
 
 WORKDIR /github/workspace
 
 ARG CHECK_TYPE
 ENV CHECK_TYPE=${INPUT_CHECK_TYPE}
 
-ENTRYPOINT ["/bin/bash", "/main.sh"]
+ENTRYPOINT ["/bin/bash", "ottr_report_scripts/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ WORKDIR /github/workspace
 ARG CHECK_TYPE
 ENV CHECK_TYPE=${INPUT_CHECK_TYPE}
 
-ENTRYPOINT ["/bin/bash", "/main.sh"]
+ENTRYPOINT ["/bin/bash", "./ottr_report_scripts/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,12 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'optparse'), \
       repos = 'https://cloud.r-project.org/')"
 
-COPY scripts/ /scripts/
-COPY main.sh ./main.sh
-RUN chmod +x main.sh
+# Install svn to copy folder from github
+RUN apt-get update && apt-get install -y --no-install-recommends subversion
+
+ADD scripts/ ./ottr_report_scripts/
+ADD main.sh ./ottr_report_scripts/main.sh
+RUN chmod +x ./ottr_report_scripts/main.sh
 
 WORKDIR /github/workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ WORKDIR /github/workspace
 ARG CHECK_TYPE
 ENV CHECK_TYPE=${INPUT_CHECK_TYPE}
 
-ENTRYPOINT ["/bin/bash", "./ottr_report_scripts/main.sh"]
+ENTRYPOINT ["/bin/bash", "/ottr_report_scripts/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,8 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
 # Install svn to copy folder from github
 RUN apt-get update && apt-get install -y --no-install-recommends subversion
 
-COPY scripts/ ./ottr_report_scripts/
-COPY main.sh ./ottr_report_scripts/main.sh
-RUN chmod +x ./ottr_report_scripts/main.sh
+COPY main.sh ./main.sh
+RUN chmod +x ./main.sh
 
 WORKDIR /github/workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ WORKDIR /github/workspace
 ARG CHECK_TYPE
 ENV CHECK_TYPE=${INPUT_CHECK_TYPE}
 
-ENTRYPOINT ["/bin/bash", "/ottr_report_scripts/main.sh"]
+ENTRYPOINT ["/bin/bash", "/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'optparse'), \
       repos = 'https://cloud.r-project.org/')"
 
-COPY main.sh ./ottr_report_scripts/main.sh
-RUN chmod +x ./ottr_report_scripts/main.sh
+COPY main.sh /ottr_report_scripts/main.sh
+RUN chmod +x /ottr_report_scripts/main.sh
 
 WORKDIR /github/workspace
 
 ARG CHECK_TYPE
 ENV CHECK_TYPE=${INPUT_CHECK_TYPE}
 
-ENTRYPOINT ["/bin/bash", "ottr_report_scripts/main.sh"]
+ENTRYPOINT ["/bin/bash", "/ottr_report_scripts/main.sh"]

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ runs:
   args:
     - ${{ inputs.check_type }}
     - ${{ inputs.error_min }}
+    - ${{ github.event.release.tag_name }}
 
 branding:
   icon: "briefcase"

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ runs:
   args:
     - ${{ inputs.check_type }}
     - ${{ inputs.error_min }}
-    - ${{ github.event.release.tag_name }}
 
 branding:
   icon: "briefcase"

--- a/main.sh
+++ b/main.sh
@@ -35,7 +35,7 @@ curl -o $script_directory/url-check.R https://raw.githubusercontent.com/jhudsl/o
 curl -o $script_directory/quiz-check.R https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R
 
 # Run the check
-chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)
+chk_results=$(Rscript $script_directory/check_type.R)
 
 # Print out the output
 printf $error_name

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-ver=$(basename $GITHUB_REF)
+ver=$(basename ${{github.event.release.tag_name}})
 printf "using version: $ver"
 
 cd $GITHUB_WORKSPACE

--- a/main.sh
+++ b/main.sh
@@ -29,7 +29,8 @@ elif [ "${INPUT_CHECK_TYPE}" == "quiz_format" ];then
 fi
 
 # Copy the scripts from this version
-curl https://github.com/jhudsl/ottr-reports/blob/v0.5/scripts/check_type.R $script_directory/ottr_report_scripts/check_type.R
+curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/check_type.R $script_directory/ottr_report_scripts/check_type.R
+
 # Run the check
 chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)
 

--- a/main.sh
+++ b/main.sh
@@ -39,6 +39,8 @@ printf $error_name
 printf $report_path
 printf $chk_results
 
+rm -rf $script_directory/ottr_report_scripts
+
 # Save output
 echo ::set-output name=error_name::$error_name
 echo ::set-output name=report_path::$report_path

--- a/main.sh
+++ b/main.sh
@@ -30,6 +30,9 @@ fi
 
 # Copy the scripts from this version
 curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/check_type.R $script_directory/ottr_report_scripts/check_type.R
+curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/spell-check.R $script_directory/ottr_report_scripts/spell-check.R
+curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/url-check.R $script_directory/ottr_report_scripts/url-check.R
+curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R $script_directory/ottr_report_scripts/quiz-check.R
 
 # Run the check
 chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-ver=$(basename $GITHUB_ACTIONS)
+ver="v0.5"
 printf "using version: $ver"
 
 cd $GITHUB_WORKSPACE
@@ -29,7 +29,7 @@ elif [ "${INPUT_CHECK_TYPE}" == "quiz_format" ];then
 fi
 
 # Copy the scripts from this version
-svn export --force https://github.com/jhudsl/ottr-reports/tree/$ver/scripts $script_directory/ottr_report_scripts
+svn export --force https://github.com/jhudsl/ottr-reports/blob/$ver/scripts $script_directory/ottr_report_scripts
 
 # Run the check
 chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)

--- a/main.sh
+++ b/main.sh
@@ -29,8 +29,7 @@ elif [ "${INPUT_CHECK_TYPE}" == "quiz_format" ];then
 fi
 
 # Copy the scripts from this version
-svn export --force https://github.com/jhudsl/ottr-reports/blob/$ver/scripts $script_directory/ottr_report_scripts
-
+curl https://github.com/jhudsl/ottr-reports/blob/v0.5/scripts/check_type.R $script_directory/ottr_report_scripts/check_type.R
 # Run the check
 chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)
 

--- a/main.sh
+++ b/main.sh
@@ -3,6 +3,7 @@
 set -e
 set -o pipefail
 
+ver=$(basename $GITHUB_REF)
 cd $GITHUB_WORKSPACE
 
 # This script should always run as if it were being called from
@@ -25,8 +26,11 @@ elif [ "${INPUT_CHECK_TYPE}" == "quiz_format" ];then
   report_path='question_error_report.tsv'
 fi
 
+# Copy the scripts from this version
+svn export --force https://github.com/jhudsl/ottr-reports/tree/$ver/scripts $script_directory/ottr_report_scripts
+
 # Run the check
-chk_results=$(Rscript $script_directory/scripts/check_type.R)
+chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)
 
 # Print out the output
 printf $error_name

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-ver=$(basename ${{github.event.release.tag_name}})
+ver=$(basename $GITHUB_ACTIONS)
 printf "using version: $ver"
 
 cd $GITHUB_WORKSPACE

--- a/main.sh
+++ b/main.sh
@@ -29,10 +29,10 @@ elif [ "${INPUT_CHECK_TYPE}" == "quiz_format" ];then
 fi
 
 # Copy the scripts from this version
-curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/check_type.R $script_directory/ottr_report_scripts/check_type.R
-curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/spell-check.R $script_directory/ottr_report_scripts/spell-check.R
-curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/url-check.R $script_directory/ottr_report_scripts/url-check.R
-curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R $script_directory/ottr_report_scripts/quiz-check.R
+curl -o $script_directory/check_type.R https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/check_type.R
+curl -o $script_directory/spell-check.R https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/spell-check.R
+curl -o $script_directory/url-check.R https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/url-check.R
+curl -o $script_directory/quiz-check.R https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R
 
 # Run the check
 chk_results=$(Rscript $script_directory/ottr_report_scripts/check_type.R)

--- a/main.sh
+++ b/main.sh
@@ -4,6 +4,8 @@ set -e
 set -o pipefail
 
 ver=$(basename $GITHUB_REF)
+printf "using version: $ver"
+
 cd $GITHUB_WORKSPACE
 
 # This script should always run as if it were being called from
@@ -12,7 +14,7 @@ script_directory="$(perl -e 'use File::Basename;
   use Cwd "abs_path";
   print dirname(abs_path(@ARGV[0]));' -- "$0")"
 
-echo $script_directory
+printf "running from: $script_directory"
 echo $INPUT_CHECK_TYPE >> check_type.txt
 
 if [ "${INPUT_CHECK_TYPE}" == "spelling" ];then

--- a/scripts/check_type.R
+++ b/scripts/check_type.R
@@ -7,6 +7,6 @@ check_type <- readLines('check_type.txt')
 
 print(paste("Check type specified:", check_type))
 
-if (check_type == "spelling") source("scripts/spell-check.R")
-if (check_type == "urls") source("scripts/url-check.R")
-if (check_type == "quiz_format") source("scripts/quiz-check.R")
+if (check_type == "spelling") source("ottr_report_scripts/spell-check.R")
+if (check_type == "urls") source("ottr_report_scripts/url-check.R")
+if (check_type == "quiz_format") source("ottr_report_scripts/quiz-check.R")

--- a/scripts/check_type.R
+++ b/scripts/check_type.R
@@ -1,12 +1,19 @@
 #!/usr/bin/env Rscript
 # Written by Candace Savonen March 2022
 
-library(optparse)
-
 check_type <- readLines('check_type.txt')
 
 print(paste("Check type specified:", check_type))
 
-if (check_type == "spelling") source("ottr_report_scripts/spell-check.R")
-if (check_type == "urls") source("ottr_report_scripts/url-check.R")
-if (check_type == "quiz_format") source("ottr_report_scripts/quiz-check.R")
+if (check_type == "spelling") {
+  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/spell-check.R spell-check.R")
+  source("spell-check.R")
+}
+if (check_type == "urls") {
+  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/url-check.R url-check.R")
+  source("url-check.R")
+}
+if (check_type == "quiz_format") {
+  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R quiz-check.R")
+  source("quiz-check.R")
+}

--- a/scripts/check_type.R
+++ b/scripts/check_type.R
@@ -5,15 +5,6 @@ check_type <- readLines('check_type.txt')
 
 print(paste("Check type specified:", check_type))
 
-if (check_type == "spelling") {
-  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/spell-check.R spell-check.R")
-  source("spell-check.R")
-}
-if (check_type == "urls") {
-  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/url-check.R url-check.R")
-  source("url-check.R")
-}
-if (check_type == "quiz_format") {
-  system("curl https://raw.githubusercontent.com/jhudsl/ottr-reports/v0.5/scripts/quiz-check.R quiz-check.R")
-  source("quiz-check.R")
-}
+if (check_type == "spelling") source("ottr_report_scripts/spell-check.R")
+if (check_type == "urls") source("ottr_report_scripts/url-check.R")
+if (check_type == "quiz_format") source("ottr_report_scripts/quiz-check.R")


### PR DESCRIPTION
I realized on https://github.com/jhudsl/ottr-reports-commenting/runs/5740039353?check_suite_focus=true
 

There is some problems with getting the scripts in a retrievable place, so I'm trying to fix the handling of how those are set up and downloaded here. 