### PR TITLE
Add safe directory flag to avoid checks crashing

### DIFF
--- a/.github/workflows/report-maker.yml
+++ b/.github/workflows/report-maker.yml
@@ -114,6 +114,7 @@ jobs:
       run: |
         branch_name='preview-${{ github.event.pull_request.number }}'
 
+        git config --system --add safe.directory "$GITHUB_WORKSPACE"
         git config --local user.email "itcrtrainingnetwork@gmail.com"
         git config --local user.name "jhudsl-robot"
 


### PR DESCRIPTION
Some weirdness has been happening with spell, url, and quiz checks. I think this is tied to checkout v3 updates and has something to do with credentials, who is committing what, etc. [Related post here](https://github.com/actions/checkout/issues/1169). 

Are there any issues with the following solution?

## The error

Basically, we get this error on the spell, url, and quiz checks:

```
 fatal: --local can only be used inside a git repository
Error: Process completed with exit code 128.
```
![image](https://user-images.githubusercontent.com/15618412/221992487-3aad2fff-3f4f-4468-a9a0-ec5e77619c84.png)

[See Example, look at spell check](https://github.com/jhudsl/AnVIL_Template/actions/runs/4297804734/jobs/7491231699)

## Solution

Adding the repo as a safe directory seems to fix the issue when the workflow is in a local file. 

![image](https://user-images.githubusercontent.com/15618412/221992841-a68a0857-d7c2-4e62-b833-179b28e3ded1.png)

[Fixed example](https://github.com/jhudsl/AnVIL_Template/actions/runs/4297756213/jobs/7491125154)




