### PR TITLE
Fixes for urls

### DIFF
--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -87,7 +87,10 @@ get_urls <- function(file) {
     url_list$markdown_bracket <- paste0("http", stringr::word(url_list$markdown_bracket, sep = "\\]: http", 2))
   }
   url_list$other_http <- stringr::word(stringr::str_extract(url_list$other_http, url_pattern), sep = "\\]", 1)
-
+  
+  # Remove trailing comma if present (are there exceptions to this? Can a URL end in a comma?)
+  url_list$other_http <- stringr::word(stringr::str_replace(url_list$other_http, "(.*)\\,$", "\\1"), sep = "\\]", 1)
+  
   # Remove parentheses only if they are on the outside
   url_list$other_http <- stringr::word(stringr::str_replace(url_list$other_http, "^\\((.*)\\)$", "\\1"), sep = "\\]", 1)
   

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -58,8 +58,8 @@ get_urls <- function(file) {
   markdown_tag <- "\\[.*\\]\\(http[s]?.*\\)"
   markdown_tag_bracket <- "\\[.*\\]: http[s]?"
   http_gen <- "http[s]?"
-  url_pattern <- "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
-
+  url_pattern <- "[(]?http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+  
   # Collect the different kinds of tags in a named vector
   all_tags <- c(html = html_tag,
                 knitr = include_url_tag,
@@ -80,7 +80,7 @@ get_urls <- function(file) {
   }
   url_list$knitr <- stringr::word(url_list$knitr, sep = "include_url\\(\"|\"\\)", 2)
   url_list$ottrpal <- stringr::word(url_list$ottrpal, sep = "include_slide\\(\"|\"\\)", 2)
-  url_list$markdown <- stringr::word(url_list$markdown, sep = "\\]\\(|\\)", 2)
+  url_list$markdown <- stringr::word(url_list$markdown, sep = "\\]\\(|\\)$", 2)
   url_list$markdown <- grep("http", url_list$markdown, value = TRUE)
 
   if (length(url_list$markdown_bracket) > 0 ){
@@ -88,6 +88,9 @@ get_urls <- function(file) {
   }
   url_list$other_http <- stringr::word(stringr::str_extract(url_list$other_http, url_pattern), sep = "\\]", 1)
 
+  # Remove parentheses only if they are on the outside
+  url_list$other_http <- stringr::word(stringr::str_replace(url_list$other_http, "^\\((.*)\\)$", "\\1"), sep = "\\]", 1)
+  
   # If after the manipulations there's not actually a URL, remove it.
   url_list <- lapply(url_list, na.omit)
 


### PR DESCRIPTION
Some issues with the URL check needed addressing. See https://github.com/jhudsl/OTTR_Template/issues/631

I think there are two problems:

- First, URL checks were failing if links were enclosed in parentheses. Example:

```
Paste the URL of the notebook (https://github.com/jhudsl/reproducible-python-example/blob/main/make_heatmap.ipynb) into the "Enter the location of a Jupyter Notebook" field and press "Go".
```

- Second, URL checks were failing if markdown flavor links truly ended in a parentheses. Example:

```
[cache](https://en.wikipedia.org/wiki/Cache_(computing)#)
```

New behavior:
- Only remove LAST `)` on markdown flavored link
- Check for leading and trailing parenthesis in text links. Remove them both with the following line:

```
# Remove parentheses only if they are on the outside
url_list$other_http <- stringr::word(stringr::str_replace(url_list$other_http, "^\\((.*)\\)$", "\\1"), sep = "\\]", 1)
```

Related:
https://github.com/jhudsl/ottr-reports/issues/17
https://github.com/jhudsl/OTTR_Template/issues/631
https://github.com/fhdsl/AI_for_software/pull/44