### PR TITLE
bug fix for url checker

### DIFF
--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -86,15 +86,17 @@ get_urls <- function(file) {
   url_list$ottrpal <- stringr::word(url_list$ottrpal, sep = "include_slide\\(\"|\"\\)", 2)
   
   # Check markdown for parentheticals outside of [ ]( )
-  x <- sapply(url_list$markdown, stringr::str_detect, nested_parens)
-  # Break down to parenthetical only
-  url_list$markdown[x] <- stringr::str_extract(url_list$markdown[x], nested_parens)
-  # Remove parentheticals outside [ ]( )
-  url_list$markdown[x] <- stringr::word(stringr::str_replace(url_list$markdown[x], outermost_parens, "\\1"), sep = "\\]", 2)
+  parens_index <- sapply(url_list$markdown, stringr::str_detect, nested_parens)
   
-  url_list$markdown[!x] <- stringr::word(url_list$markdown[!x], sep = "\\]", 2)
-  url_list$markdown <- grep("http", url_list$markdown, value = TRUE)
-
+  if (length(parens_index) >= 1) {
+    # Break down to parenthetical only
+    url_list$markdown[parens_index] <- stringr::str_extract(url_list$markdown[parens_index], nested_parens)
+    # Remove parentheticals outside [ ]( )
+    url_list$markdown[parens_index] <- stringr::word(stringr::str_replace(url_list$markdown[parens_index], outermost_parens, "\\1"), sep = "\\]", 2)
+  
+    url_list$markdown[!parens_index] <- stringr::word(url_list$markdown[!parens_index], sep = "\\]", 2)
+    url_list$markdown <- grep("http", url_list$markdown, value = TRUE)
+  }
   if (length(url_list$markdown_bracket) > 0 ){
     url_list$markdown_bracket <- paste0("http", stringr::word(url_list$markdown_bracket, sep = "\\]: http", 2))
   }


### PR DESCRIPTION
## Background

This is related to this issue: https://github.com/jhudsl/ottrpal/issues/141

If there were no nested parents detected in a particular file, it was throwing an error in the script. 

If this bit rendered a vector of length 0 then the following steps were throwing errors. 
```
x <- sapply(url_list$markdown, stringr::str_detect, nested_parens)
```

I changed two things: 

1. I added logic so it skips the steps if there are no nested parenthesis detected and 
2. I changed the vector named `x` to `parens_index` just for readability purposes. 


### How I tested it: 

This file attached below from DataTrail was making DataTrail fail in the URL test with the same error reported in https://github.com/jhudsl/ottrpal/issues/141

[01_forming_questions_00.Rmd.zip](https://github.com/jhudsl/ottr-reports/files/11627099/01_forming_questions_00.Rmd.zip)

So I used this file as my test. It no longer fails but completes the test successfully. 