### PR TITLE
Don't check URLs in ignore list

### DIFF
--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -38,7 +38,7 @@ test_url <- function(url) {
 
    if (status == "success") {
      # Fails if 404'ed
-     status <- ifelse(try(httr::GET(url)$status_code, silent = TRUE) == 404, "failed", "success")
+     status <- ifelse(try(url_status$status_code, silent = TRUE) == 404, "failed", "success")
    }
 
    return(status)

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -29,6 +29,12 @@ if (file.exists(ignore_urls_file)) {
 files <- list.files(path = root_dir, pattern = 'md$', full.names = TRUE)
 
 test_url <- function(url) {
+
+   if (url %in% ignore_urls) {
+     message(paste0("Ignoring: ", url))
+     return("ignored")
+   }
+
    message(paste0("Testing: ", url))
 
    url_status <- try(httr::GET(url), silent = TRUE)


### PR DESCRIPTION
I was running into an issue with the url-check.R script.  The course site I am building contains links to some very large files, which cause the checker to fail.  When I added those URLs to the `ignore-urls.txt`, the script still failed since it tries to `GET` the link (twice!) before throwing the results of the check away.

This PR re-uses the status from the first `GET` call and also checks the ignore list inside of `test_url()` reporting back a status of `ignored` instead of `success` or `failure`.  With these changes I was able to run the script on my project and have it report properly.

That result is still filtered out before the report is made; I could imagine also removing the `dplyr::filter(!(urls %in% ignore_urls))` from the end of the script since they still won't be included by the `failed` filter as is.