### PR TITLE
Add accent debugging to spell check

### DIFF
--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -57,7 +57,7 @@ tryCatch(
     }
   },
   error = function(e){
-    message("Spell check did not work. Check that your dictionary is formatted correctly. You cannot have special characters (e.g., ó) in the dictionary.txt file. You need to use TeX formatting (e.g., \\'{o}) for these.")
+    message("Spell check did not work. Check that your dictionary is formatted correctly. You cannot have special characters (e.g., Diné) in the dictionary.txt file. You need to use HTML formatting (e.g., Din&eacute;) for these.")
   }
 )
 

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -42,17 +42,24 @@ files <- c(files, quiz_files)
 files <- grep("About.Rmd", files, ignore.case = TRUE, invert = TRUE, value = TRUE)
 files <- grep("style-sets", files, ignore.case = TRUE, invert = TRUE, value = TRUE)
 
-# Run spell check
-sp_errors <- spelling::spell_check_files(files, ignore = dictionary)
-
-if (nrow(sp_errors) > 0) {
-  sp_errors <- sp_errors %>%
-    data.frame() %>%
-    tidyr::unnest(cols = found) %>%
-    tidyr::separate(found, into = c("file", "lines"), sep = ":")
-} else {
-  sp_errors <- data.frame(errors = NA)
-}
+tryCatch( 
+  expr = {
+    # Run spell check
+    sp_errors <- spelling::spell_check_files(files, ignore = dictionary)
+    
+    if (nrow(sp_errors) > 0) {
+      sp_errors <- sp_errors %>%
+        data.frame() %>%
+        tidyr::unnest(cols = found) %>%
+        tidyr::separate(found, into = c("file", "lines"), sep = ":")
+    } else {
+      sp_errors <- data.frame(errors = NA)
+    }
+  },
+  error = function(e){
+    message("Spell check did not work. Check that your dictionary is formatted correctly. You cannot have special characters (e.g., ó) in the dictionary.txt file. You need to use TeX formatting (e.g., \\'{o}) for these.")
+  }
+)
 
 # Print out how many spell check errors
 write(nrow(sp_errors), stdout())


### PR DESCRIPTION
Was getting some confusing errors when adding words with accents to dictionary.txt. It wouldn't run, and I wasn't sure why :) 

```
> sp_errors <- spelling::spell_check_files(files, ignore = dictionary)
Error in chartr("’", "'", as.character(add_words)) : 
  invalid input multibyte string 22
```

In other words, "Diné" in the dictionary.txt file was causing the spell check to break. I needed to use html inside the Rmd file (e.g. `Din&eacute;`).

Added some messaging to try to make this easier to diagnose from the Actions log.

Works as expected when tested locally, but there could be some edge cases. 