### PR TITLE
Add exclude_files.txt feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# ignore nonsense files
+.DS_Store
+.Rhistory
+.local
+.rstudio
+.bash_history
+.RData
+.httr-oauth
+docker/git_token.txt
+.Rproj.user
+docs/*

--- a/resources/exclude_files.txt
+++ b/resources/exclude_files.txt
@@ -1,0 +1,1 @@
+CONTRIBUTING.md

--- a/resources/exclude_files.txt
+++ b/resources/exclude_files.txt
@@ -1,2 +1,4 @@
 About.Rmd
 docs/*
+style-sets/*
+manuscript/*

--- a/resources/exclude_files.txt
+++ b/resources/exclude_files.txt
@@ -1,1 +1,2 @@
-CONTRIBUTING.md
+About.Rmd
+docs/*

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -52,14 +52,13 @@ quiz_files <- list.files(file.path(root_dir, "quizzes"), pattern = '\\.md$', ful
 # Put into one list
 files <- c(files, quiz_files)
 
-files <- grep("About.Rmd", files, ignore.case = TRUE, invert = TRUE, value = TRUE)
 files <- grep("style-sets", files, ignore.case = TRUE, invert = TRUE, value = TRUE)
 
-tryCatch( 
+tryCatch(
   expr = {
     # Run spell check
     sp_errors <- spelling::spell_check_files(files, ignore = dictionary)
-    
+
     if (nrow(sp_errors) > 0) {
       sp_errors <- sp_errors %>%
         data.frame() %>%

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -27,11 +27,24 @@ if (!dir.exists('check_reports')) {
 dict_file <- file.path(root_dir, 'resources', 'dictionary.txt')
 dictionary <- readLines(dict_file)
 
+# Declare exclude_files.txt
+exclude_file <- file.path(root_dir, 'resources', 'exclude_files.txt')
+
+# Read in exclude_files.txt if it exists
+if (file.exists(exclude_file)) {
+  exclude_file <- readLines(exclude_file)
+} else {
+  exclude_file <- ""
+}
+
 # Make it alphabetical and only unique entries
 writeLines(unique(sort(dictionary)), dict_file)
 
 # Only declare `.Rmd` files but not the ones in the style-sets directory
 files <- list.files(pattern = 'md$', recursive = TRUE, full.names = TRUE)
+
+# Exclude files lists in the exclude_file
+files <- setdiff(files, file.path(root_dir, exclude_file))
 
 # Get quiz file names
 quiz_files <- list.files(file.path(root_dir, "quizzes"), pattern = '\\.md$', full.names = TRUE)

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -37,22 +37,10 @@ if (file.exists(exclude_file)) {
   exclude_file <- ""
 }
 
-# Make it alphabetical and only unique entries
-writeLines(unique(sort(dictionary)), dict_file)
-
 # Only declare `.Rmd` files but not the ones in the style-sets directory
 files <- list.files(pattern = 'md$', recursive = TRUE, full.names = TRUE)
 
-# Exclude files lists in the exclude_file
-files <- setdiff(files, file.path(root_dir, exclude_file))
-
-# Get quiz file names
-quiz_files <- list.files(file.path(root_dir, "quizzes"), pattern = '\\.md$', full.names = TRUE)
-
-# Put into one list
-files <- c(files, quiz_files)
-
-files <- grep("style-sets", files, ignore.case = TRUE, invert = TRUE, value = TRUE)
+if( exclude_file[1] != "") files <- grep(paste0(exclude_file, collapse = "|"), files, invert = TRUE, value = TRUE)
 
 tryCatch(
   expr = {

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -34,12 +34,11 @@ if (file.exists(exclude_file)) {
 } else {
   exclude_file <- ""
 }
-
+           
 # Only declare `.md` files but not the ones in the style-sets directory
-files <- list.files(path = root_dir, pattern = 'md$', full.names = TRUE)
+files <- list.files(path = root_dir, pattern = 'md$', full.names = TRUE, recursive = TRUE)
 
-# Exclude files lists in the exclude_file
-files <- setdiff(files, file.path(root_dir, exclude_file))
+if( exclude_file[1] != "") files <- grep(paste0(exclude_file, collapse = "|"), files, invert = TRUE, value = TRUE)
 
 test_url <- function(url) {
 

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -18,6 +18,9 @@ if (!dir.exists('check_reports')) {
 # Declare ignore_urls file
 ignore_urls_file <- file.path(root_dir, 'resources', 'ignore-urls.txt')
 
+# Declare exclude_files.txt
+exclude_file <- file.path(root_dir, 'resources', 'exclude_files.txt')
+
 # Read in ignore urls file if it exists
 if (file.exists(ignore_urls_file)) {
   ignore_urls <- readLines(ignore_urls_file)
@@ -25,8 +28,18 @@ if (file.exists(ignore_urls_file)) {
   ignore_urls <- ""
 }
 
+# Read in ignore urls file if it exists
+if (file.exists(exclude_file)) {
+  exclude_file <- readLines(exclude_file)
+} else {
+  exclude_file <- ""
+}
+
 # Only declare `.md` files but not the ones in the style-sets directory
 files <- list.files(path = root_dir, pattern = 'md$', full.names = TRUE)
+
+# Exclude files lists in the exclude_file
+files <- setdiff(files, file.path(root_dir, exclude_file))
 
 test_url <- function(url) {
 


### PR DESCRIPTION
## Summary 

Need to add documentation somewhere but the idea here is that someone can add files they'd like to ignore in the "exclude_files.txt" file. Much like the dictionary.txt and "ignore-urls.txt" file. 

This should resolve #28 