### PR TITLE
Add rebase for checks

### DIFF
--- a/.github/workflows/report-maker.yml
+++ b/.github/workflows/report-maker.yml
@@ -149,7 +149,7 @@ jobs:
 
         git add ${{ steps.check_results.outputs.report_path }} --force || echo "No changes to commit"
         git commit -m 'Add check file' || echo "No changes to commit"
-        git pull
+        git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
         git merge origin/${{ github.head_ref }} --allow-unrelated-histories --strategy-option ours
         git push origin $branch_name --force || echo "No changes to commit"
 


### PR DESCRIPTION
## Summary 

I think @avahoffman 's Rebase solution is good for the preview branch but for this to be used it needs to be implemented here too. 

Carried over from: https://github.com/jhudsl/OTTR_Template/pull/756

```
git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
```