### PR TITLE
webshot -> webshot2

### DIFF
--- a/scripts/make_screenshots.R
+++ b/scripts/make_screenshots.R
@@ -53,17 +53,31 @@ if (is.null(opt$base_url)) {
   base_url <- gsub("/$", "", base_url)
 }
 
-chapt_df <- ottrpal::get_chapters(base_url = file.path(base_url, "no_toc/"))
+# Collect all the chapter pages for the url given
+chapt_df <- get_chapters(html_page = file.path(base_url, "no_toc/"))
 
+
+# Now take screenshots for each
 file_names <- lapply(chapt_df$url, function(url) {
   file_name <- gsub(".html", ".png", file.path(output_folder, basename(url)))
-  b <- chromote::ChromoteSession$new()
-  # Get rid of special characters
-  b$Page$navigate(url, file_name)
+
+  # Open a session
+  chrome_session <- chromote::ChromoteSession$new()
+
+  # Get rid of special characters because leanpub no like
+  suppressWarnings(chrome_session$Page$navigate(url, "_", file_name))
   file_name <- gsub(":|?|!|\\'", "", file_name)
-  b$screenshot(file_name)
+
+  # Take the screenshot
+  chrome_session$screenshot(file.path(file_name))
+
   message(paste("Screenshot saved:", file_name))
+
+  # Close it
+  chrome_session$close()
+
   return(file_name)
+
 })
 
 # Save file of chapter urls and file_names

--- a/scripts/make_screenshots.R
+++ b/scripts/make_screenshots.R
@@ -54,21 +54,21 @@ if (is.null(opt$base_url)) {
 }
 
 # Collect all the chapter pages for the url given
-chapt_df <- get_chapters(html_page = file.path(base_url, "no_toc/"))
+chapt_df <- ottrpal::get_chapters(html_page = file.path(base_url, "no_toc/"))
 
 
 # Now take screenshots for each
 file_names <- lapply(chapt_df$url, function(url) {
   file_name <- gsub(".html", ".png", file.path(output_folder, basename(url)))
-
+  
   # Get rid of special characters because leanpub no like
   file_name <- gsub(":|?|!|\\'", "", file_name)
   
   # Take the screenshot
-  webshot2::webshot(url)
-
+  webshot2::webshot(url, file = file_name)
+  
   return(file_name)
-
+  
 })
 
 # Save file of chapter urls and file_names

--- a/scripts/make_screenshots.R
+++ b/scripts/make_screenshots.R
@@ -9,8 +9,6 @@ if (!('optparse' %in% installed.packages())) {
   # install.packages("optparse", repos = "http://cran.us.r-project.org")
 }
 
-webshot::install_phantomjs()
-
 library(optparse)
 library(magrittr)
 
@@ -59,9 +57,11 @@ chapt_df <- ottrpal::get_chapters(base_url = file.path(base_url, "no_toc/"))
 
 file_names <- lapply(chapt_df$url, function(url) {
   file_name <- gsub(".html", ".png", file.path(output_folder, basename(url)))
+  b <- chromote::ChromoteSession$new()
   # Get rid of special characters
-  webshot::webshot(url, file_name)
+  b$Page$navigate(url, file_name)
   file_name <- gsub(":|?|!|\\'", "", file_name)
+  b$screenshot(file_name)
   message(paste("Screenshot saved:", file_name))
   return(file_name)
 })

--- a/scripts/make_screenshots.R
+++ b/scripts/make_screenshots.R
@@ -61,20 +61,11 @@ chapt_df <- get_chapters(html_page = file.path(base_url, "no_toc/"))
 file_names <- lapply(chapt_df$url, function(url) {
   file_name <- gsub(".html", ".png", file.path(output_folder, basename(url)))
 
-  # Open a session
-  chrome_session <- chromote::ChromoteSession$new()
-
   # Get rid of special characters because leanpub no like
-  suppressWarnings(chrome_session$Page$navigate(url, "_", file_name))
   file_name <- gsub(":|?|!|\\'", "", file_name)
-
+  
   # Take the screenshot
-  chrome_session$screenshot(file.path(file_name))
-
-  message(paste("Screenshot saved:", file_name))
-
-  # Close it
-  chrome_session$close()
+  webshot2::webshot(url)
 
   return(file_name)
 


### PR DESCRIPTION
phantomjs is long dead. Need a new screenshot thing because the docker image won't build with the dead phantomJS. This is replacing webshot with webshot2! 

Will have some associated ottrpal docker image updates with this!

Really the make_screenshots.R needs to be dissolved by adding the functionality to the ottrpal. But one thing at a time!

## Testing

Here's how I tested this locally: 

Ran make_screenshots.R with: 

```
opt$output_dir <- "resources/chapt_screen_images"
opt$git_pat <- "super secret GH_PAT here"
opt$repo <- "jhudsl/OTTR_Template"
```
Then ran: 

```
ottrpal::bookdown_to_embed_leanpub(
     render = FALSE, 
     chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', 
     make_book_txt = TRUE)
```