### PR TITLE
Add Job to automatically sort the dictionary file if desired.

### DIFF
--- a/.github/workflows/report-maker.yml
+++ b/.github/workflows/report-maker.yml
@@ -13,12 +13,15 @@ on:
       error_min:
         default: 0
         type: number
-      gh_pat:
-        type: string
-        required: true
+      sort_dictionary:
+        default: false
+        type: boolean
       branch_name:
         type: string
         default: ${GITHUB_REF#refs/heads/}
+    secrets:
+      gh_pat:
+        required: true
 jobs:
   status-update:
     runs-on: ubuntu-latest
@@ -196,3 +199,52 @@ jobs:
           No ${{ steps.setup2.outputs.error_name }}! :tada:
           _Comment updated at ${{ steps.build-components2.outputs.time }} with changes from ${{ steps.build-components2.outputs.commit_id }}_
         edit-mode: replace
+
+  sort-dictionary:
+    runs-on: ubuntu-latest
+    if:  inputs.sort_dictionary && inputs.check_type == 'spelling'
+    steps:
+    - name: "Check out PR branch"
+      id: checkout-pr-branch
+      uses: actions/checkout@v4
+
+    - name: "Check write permissions"
+      id: check-write-permissions
+      run: |
+         sudo apt-get install -y jq
+         WRITE_PERMISSION=$(curl -s -H "Authorization: token ${{ secrets.gh_pat }}"  https://api.github.com/repos/${{ github.repository }} | jq '.permissions.push')
+         if [ $WRITE_PERMISSION != "true" ]; then
+          echo "Do not have write permissions to the repo"
+          exit 1
+         fi
+    - name: "Sort dictionary file"
+      id: sort-dictionary
+      # Only run the sort if we're going to be able to commit the result back
+      if: steps.check-write-permissions.outcome == 'success'
+      run: |
+        dictionary_file="resources/dictionary.txt"
+        tmp_dictionary_file="resources/dictionary.txt.sorted"
+        pr_branch=${{ inputs.branch_name }}
+        git fetch origin
+        git checkout $pr_branch
+        if [ -e $dictionary_file ]; then
+          sort -f $dictionary_file > $tmp_dictionary_file
+          if ! diff $dictionary_file $tmp_dictionary_file ; then
+            #The files are different, we need to commit
+            rm $dictionary_file
+            mv $tmp_dictionary_file $dictionary_file
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add $dictionary_file
+            git commit -m 'Sort dictionary file'
+            git pull --rebase --set-upstream origin $pr_branch --allow-unrelated-histories --strategy-option=ours
+            git push origin $pr_branch
+            exit 0
+          else
+            echo "No changes in dictionary.txt"
+            exit 0
+          fi
+        else
+          echo "Dictionary not found at expected location"
+          exit 1
+        fi

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: "There are three types of reports that can be done and specified: 'spelling', 'urls', or 'quiz_format'."
     required: true
     type: string
+  sort_dictionary:
+    description: "Should this action automatically alphabetize your dictionary.txt"
+    default: false
+    type: boolean
   error_min:
     description: "What number of errors should make this check fail?"
     default: 0


### PR DESCRIPTION
This introduces a new input boolean: `sort_dictionary` which defaults to `false`. (I figured it would be best if we didn't start committing to peoples' repositories automatically without them opting into the behavior.)

If the user sets `sort_dictionary` to `true`,  another job will run when check spelling is run. The job will 

* check out the PR branch
* ensure that the provided GH_PAT has write permissions to the repo in question
* sort the dictionary file into a temporary file and check if they differ
* if so, it deletes the old dictionary file and moves the new one into place, then commits and pushes to the PR branch.


As best as I can tell, it appears that the `gh_pat` token was not being used the report maker action previously. The way it is currently being invoked [(see here)](https://github.com/jhudsl/OTTR_Template/blob/main/.github/workflows/pull_request.yml#L63) passes the literal string `secrets.GH_PAT` into report-maker. Changing it to `${{ secrets.GH_PAT }}` to get the value directly throws an error because you cannot pass a secret in via an input like that, it needs to be passed in explicitly as a secret . You can see an updated version that functions as expected in the course I've been using the test this [here](https://github.com/acoffman/test-course/blob/demo-dictionary-sort/.github/workflows/pull_request.yml#L60).

If that looks correct to you, I can also create a PR back the OTTR_Template repo with the change. I have a test course repo with a PR demonstrating to new behavior [here](https://github.com/acoffman/test-course/pull/7)

I can also go ahead and update the README to document this new option if you're okay with this approach in general.

closes jhudsl/OTTR_Template#233